### PR TITLE
feat: Migrate to Rust 2024 Edition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,14 @@
 name: CI
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, edition-2024-migration ]
   pull_request:
     branches: [ main ]
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Minimum Rust version for 2024 edition
+  MSRV: '1.85.0'
 jobs:
   test:
     name: Test Suite
@@ -17,48 +19,76 @@ jobs:
           - stable
           - beta
           - nightly
+          - '1.85.0'  # MSRV for Rust 2024 edition
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4
+    
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
         components: rustfmt, clippy
+    
     - name: Cache cargo registry
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-${{ matrix.rust }}-
+          ${{ runner.os }}-cargo-
+    
+    - name: Verify Rust 2024 edition compatibility
+      run: |
+        echo "Rust version: $(rustc --version)"
+        echo "Cargo version: $(cargo --version)"
+        rustc --version | grep -E '1\.(8[5-9]|9[0-9]|[1-9][0-9]{2})' || {
+          echo "Warning: Rust version may not fully support 2024 edition"
+        }
+    
     - name: Run cargo check
       run: cargo check --all --all-features
+    
     - name: Run cargo test
       run: cargo test --all --all-features
+    
     - name: Run rustfmt
       run: cargo fmt --all -- --check
+    
     - name: Run clippy
       run: cargo clippy --all --all-features -- -D warnings -A clippy::missing_errors_doc -A clippy::missing_panics_doc
+  
   build:
     name: Build Release
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4
-    - name: Install Rust toolchain
+    
+    - name: Install Rust toolchain (stable)
       uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt, clippy
+    
     - name: Cache cargo
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-release-
+          ${{ runner.os }}-cargo-
+    
     - name: Build
       run: cargo build --release --all --all-features
+    
     - name: Test CLI (if CLI crate exists)
       run: |
         if [ -d "crates/cli" ]; then
@@ -66,20 +96,65 @@ jobs:
         else
           echo "CLI crate not found, skipping CLI test"
         fi
+  
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4
-    - name: Install Rust toolchain
+    
+    - name: Install Rust toolchain (stable 1.85+)
       uses: dtolnay/rust-toolchain@stable
+    
+    - name: Cache cargo
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+    
     - name: Install cargo-tarpaulin
       run: cargo install cargo-tarpaulin --locked
+    
     - name: Generate code coverage
       run: cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml --ignore-tests
+    
     - name: Upload to codecov.io
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
+  
+  # New job: Edition 2024 migration checks
+  edition-check:
+    name: Edition 2024 Compatibility
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+    
+    - name: Install Rust 1.85.0 (minimum for 2024 edition)
+      uses: dtolnay/rust-toolchain@v1
+      with:
+        toolchain: '1.85.0'
+        components: rustfmt, clippy
+    
+    - name: Verify edition in Cargo.toml
+      run: |
+        if grep -q 'edition = "2024"' Cargo.toml; then
+          echo "✅ Rust 2024 edition detected"
+        else
+          echo "❌ Rust 2024 edition not found in Cargo.toml"
+          exit 1
+        fi
+    
+    - name: Check all crates compile with 2024 edition
+      run: cargo check --all --all-features
+    
+    - name: Run edition-specific lints
+      run: |
+        echo "Running Rust 2024 edition compatibility checks"
+        cargo clippy --all --all-features -- -W rust-2024-compatibility || true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ resolver = "2"
 
 [workspace.package]
 version = "0.2.0"
-edition = "2021"
-rust-version = "1.82" # Latest stable Rust as of 2025
+edition = "2024"  # Updated from 2021
+rust-version = "1.85"  # Updated from 1.82 for 2024 edition support
 authors = ["NEXUS Contributors"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Gzeu/nexus"

--- a/MIGRATION-2024.md
+++ b/MIGRATION-2024.md
@@ -1,0 +1,235 @@
+# Rust 2024 Edition Migration Guide for NEXUS
+
+**Migration Date:** November 7, 2025  
+**Previous Edition:** 2021  
+**New Edition:** 2024  
+**Minimum Rust Version:** 1.85.0
+
+## Overview
+
+This document outlines the migration of NEXUS from Rust Edition 2021 to Edition 2024, which was released on February 20, 2025 with Rust 1.85.0.
+
+## Changes Made
+
+### Configuration Updates
+
+1. **Cargo.toml** (Workspace)
+   - `edition = "2024"` (updated from `"2021"`)
+   - `rust-version = "1.85"` (updated from `"1.82"`)
+
+2. **rustfmt.toml**
+   - `edition = "2024"`
+   - `style_edition = "2021"` (added to preserve existing formatting)
+
+## Next Steps for Local Development
+
+After pulling this branch, you'll need to:
+
+### 1. Update Rust Toolchain
+
+```bash
+# Update to latest stable (must be 1.85.0 or newer)
+rustup update stable
+rustup default stable
+
+# Verify version
+rustc --version  # Should show 1.85.0 or higher
+```
+
+### 2. Run Automated Migration Fixes
+
+```bash
+# This will automatically fix edition-specific issues
+cargo fix --edition --all-features --allow-dirty
+
+# Review the changes made by cargo fix
+git diff
+```
+
+### 3. Build and Test
+
+```bash
+# Clean build
+cargo clean
+cargo build --all-features
+
+# Run tests
+cargo test --all-features
+
+# Run clippy
+cargo clippy --all-features -- -D warnings
+
+# Check formatting
+cargo fmt --all -- --check
+```
+
+### 4. Address Manual Fixes (if needed)
+
+Some changes may require manual intervention:
+
+#### Temporary Lifetime Changes
+
+```rust
+// If you encounter lifetime issues, you may need to add explicit scopes
+{
+    if let Some(x) = get_option() {
+        use_reference(&x);
+    }
+}
+```
+
+#### Pattern Matching
+
+`cargo fix --edition` may aggressively convert `if let` to `match`. Review these:
+
+```rust
+// Original (might be preferred)
+if let Some(value) = option {
+    process(value);
+}
+
+// Auto-generated (review if this is better)
+match option {
+    Some(value) => process(value),
+    None => {}
+}
+```
+
+## New Features Available in Rust 2024
+
+### 1. Async Closures
+
+You can now use async closures directly:
+
+```rust
+// New in 2024!
+let async_closure = async || {
+    fetch_data().await
+};
+
+// Useful in agent system
+agent.map(async |data| {
+    process_async(data).await
+})
+```
+
+### 2. RPIT Lifetime Capture
+
+Improved `impl Trait` return position lifetime capture:
+
+```rust
+pub trait BlockchainClient {
+    async fn get_balance(&self, address: Address) 
+        -> impl Future<Output = Result<Balance>> + use<'_>;
+}
+```
+
+### 3. Reserved Keywords
+
+- `gen` - Reserved for future generators
+- `async gen` - Reserved for async generators
+
+Ensure you don't use these as identifiers.
+
+### 4. Enhanced Unsafe Blocks
+
+Unsafe extern blocks now require explicit `unsafe` keyword:
+
+```rust
+// 2024 edition requires
+unsafe extern "C" {
+    fn external_function();
+}
+```
+
+## CI/CD Updates Required
+
+Update GitHub Actions workflows to use Rust 1.85+:
+
+```yaml
+- name: Install Rust
+  uses: actions-rs/toolchain@v1
+  with:
+    toolchain: 1.85.0  # or 'stable'
+    profile: minimal
+    override: true
+```
+
+## Formatting Style
+
+We've chosen to preserve 2021 formatting style (`style_edition = "2021"`) during the initial migration. This prevents unnecessary whitespace-only commits.
+
+### Future: Adopting 2024 Formatting
+
+When ready to adopt 2024 formatting improvements:
+
+1. Remove or update `style_edition` in `rustfmt.toml`
+2. Run `cargo fmt --all`
+3. Commit formatting changes separately
+
+## Breaking Changes Summary
+
+1. **Temporary Scopes**: Changes to `if let` and tail expression temporary scopes
+2. **Pattern Matching**: More aggressive pattern matching suggestions
+3. **Unsafe Blocks**: Stricter requirements for unsafe extern blocks
+4. **Reserved Keywords**: Cannot use `gen` as identifier
+5. **Lifetime Inference**: More precise RPIT lifetime capture
+
+## Benefits for NEXUS
+
+- **Async Closures**: Simplifies AI agent orchestration
+- **Better Lifetime Inference**: Cleaner Web3 trait implementations
+- **Enhanced Safety**: Improved unsafe block requirements
+- **Future-Ready**: Prepared for upcoming async generators
+- **Modern Patterns**: Latest Rust idioms and best practices
+
+## Rollback Procedure
+
+If issues arise:
+
+```bash
+# Switch back to main branch
+git checkout main
+
+# Or revert edition in Cargo.toml
+edition = "2021"
+rust-version = "1.82"
+```
+
+## Testing Checklist
+
+- [ ] All crates build successfully
+- [ ] All tests pass (`cargo test --all-features`)
+- [ ] Clippy checks pass (`cargo clippy --all-features`)
+- [ ] Documentation builds (`cargo doc --all-features --no-deps`)
+- [ ] Formatting is consistent (`cargo fmt --all -- --check`)
+- [ ] CI/CD pipeline passes
+- [ ] Local development workflow works
+- [ ] Plugin system functions correctly
+- [ ] AI engine integration works
+- [ ] Web3 operations succeed
+
+## Resources
+
+- [Rust 2024 Edition Guide](https://doc.rust-lang.org/edition-guide/rust-2024/)
+- [Rust 1.85.0 Announcement](https://blog.rust-lang.org/2025/02/19/Rust-1.85.0.html)
+- [Edition Migration Guide](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html)
+- [Cargo Fix Documentation](https://doc.rust-lang.org/cargo/commands/cargo-fix.html)
+
+## Questions or Issues?
+
+If you encounter problems during migration:
+
+1. Check this guide for known issues
+2. Review `cargo fix --edition` output carefully
+3. Run `cargo check` to see detailed error messages
+4. Open an issue on GitHub with:
+   - Error message
+   - Affected crate/file
+   - Rust version (`rustc --version`)
+   - Steps to reproduce
+
+---
+
+**Status:** ✅ Configuration files updated  
+**Next:** Run `cargo fix --edition` locally and test thoroughly

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,7 @@
-# Rust formatting configuration
-edition = "2021"
+# Rust formatting configuration - 2024 Edition
+edition = "2024"  # Updated from 2021
+style_edition = "2021"  # Preserve 2021 formatting style for gradual migration
+
 max_width = 100
 hard_tabs = false
 tab_spaces = 4


### PR DESCRIPTION
## 🦀 Rust 2024 Edition Migration

This PR migrates the NEXUS project from **Rust Edition 2021** to **Rust Edition 2024**, which was released on February 20, 2025 with Rust 1.85.0.

### 📝 Changes Made

#### Configuration Updates
- **Cargo.toml**: Updated `edition = "2024"` and `rust-version = "1.85"`
- **rustfmt.toml**: Updated to edition 2024 while preserving 2021 formatting style (`style_edition = "2021"`)
- **CI/CD**: Updated GitHub Actions to use Rust 1.85.0+ with edition compatibility checks

#### Documentation
- Added **MIGRATION-2024.md** with comprehensive migration guide
- Includes next steps for local development
- Documents new features and breaking changes

### ✨ New Features Available

With Rust 2024 edition, NEXUS can now leverage:

1. **Async Closures** - Native `async || {}` closures for cleaner agent orchestration
2. **RPIT Lifetime Capture** - Improved `impl Trait` return types for Web3 traits
3. **Enhanced Safety** - Stricter unsafe block requirements
4. **Better Pattern Matching** - Improved match ergonomics
5. **Future-Ready** - Reserved keywords for upcoming async generators

### 🛠️ Next Steps for Reviewers/Developers

After merging this PR, developers will need to:

1. **Update Rust toolchain**:
   ```bash
   rustup update stable
   rustc --version  # Should be 1.85.0 or higher
   ```

2. **Run automated migration fixes**:
   ```bash
   cargo fix --edition --all-features --allow-dirty
   ```

3. **Build and test**:
   ```bash
   cargo clean
   cargo build --all-features
   cargo test --all-features
   cargo clippy --all-features
   ```

See **MIGRATION-2024.md** for complete details.

### ✅ Testing Checklist

- [x] Configuration files updated to 2024 edition
- [x] CI/CD workflows updated for Rust 1.85+
- [x] Migration documentation added
- [ ] Local `cargo fix --edition` to be run after merge
- [ ] All tests pass (to be verified after cargo fix)
- [ ] Clippy checks pass
- [ ] Documentation builds

### 📚 Resources

- [Rust 2024 Edition Guide](https://doc.rust-lang.org/edition-guide/rust-2024/)
- [Rust 1.85.0 Announcement](https://blog.rust-lang.org/2025/02/19/Rust-1.85.0.html)
- [Edition Migration Guide](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html)

### 👀 Breaking Changes

This is a **semi-breaking change** that requires:
- Minimum Rust version: **1.85.0**
- Running `cargo fix --edition` locally after pulling
- Potential manual fixes for temporary lifetime scopes

The migration preserves 2021 formatting style to minimize whitespace-only changes.

### 🔗 Related

- Closes #<issue-number-if-exists>
- Part of NEXUS 2025 modernization roadmap

---

**Migration Status**: ✅ Configuration complete, awaiting local `cargo fix` and testing